### PR TITLE
Update scope of plugin options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [1.0.3] - 
+## [1.0.4] - 2019-11-19
+
+### Changed
+
+- Only export plugin opts in TEST mode
+- TEST mode can get/set plugin opts from outside the plugin, non-TEST mode can only get plugin opts inside the plugin
+
+## [1.0.3] - 2019-11-18
 
 ### Added
 

--- a/io/plugin.js
+++ b/io/plugin.js
@@ -7,24 +7,21 @@ import consola from 'consola'
 
 function PluginOptions() {
   let _pluginOptions
-  return Object.freeze({
-    get() {
-      if (!process.env.TEST) {
-        return <%= JSON.stringify(options) %>
-      }
-      return _pluginOptions
-    },
-    set(opts) {
-      _pluginOptions = opts
-    }
-  })
+  const svc = {}
+  if (process.env.TEST) {
+    svc.get = () => (_pluginOptions)
+    svc.set = (opts) => _pluginOptions = opts
+  } else {
+    svc.get = () => (<%= JSON.stringify(options) %>)
+  }
+  return Object.freeze(svc)
 }
 
-export const pOptions = PluginOptions()
+const _pOptions = PluginOptions()
 
 function nuxtSocket(ioOpts) {
   const { name, channel = '', ...connectOpts } = ioOpts
-  const pluginOptions = pOptions.get()
+  const pluginOptions = _pOptions.get()
   const { sockets } = pluginOptions
   const { $store: store } = this
 
@@ -129,4 +126,10 @@ function nuxtSocket(ioOpts) {
 
 export default function(context, inject) {
   inject('nuxtSocket', nuxtSocket)
+}
+
+export let pOptions
+if (process.env.TEST) {
+  pOptions = {}
+  Object.assign(pOptions, _pOptions)
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-socket-io",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Socket.io module for Nuxt. Just plug it in and GO",
   "author": "Richard Schloss",
   "main": "io/module.js",


### PR DESCRIPTION
- Plugin options can be accessed and set in TEST mode only by the test.
- When not in test mode, only the plugin can access the options. Setting plugin options is disabled in this mode.