### PR TITLE
Improved compilePlugin method.

### DIFF
--- a/io/plugin.js
+++ b/io/plugin.js
@@ -104,8 +104,7 @@ function nuxtSocket(ioOpts) {
               Object.prototype.hasOwnProperty.call(watchProp, '__ob__')
             ) {
               const errMsg =
-                emitBack +
-                ' is a vuex module. You probably want to watch its properties'
+                `${emitBack} is a vuex module. You probably want to watch its properties`
               throw new Error(errMsg)
             }
             return watchProp

--- a/test/utils.js
+++ b/test/utils.js
@@ -2,6 +2,7 @@
 import fs from 'fs'
 import template from 'lodash/template'
 import { Nuxt, Builder } from 'nuxt'
+import serialize from 'serialize-javascript'
 import config from '@/nuxt.config'
 import { IOServer } from '@/server/io'
 
@@ -11,8 +12,8 @@ const oneMinute = 60 * oneSecond
 export async function compilePlugin({ src, tmpFile, options }) {
   const content = fs.readFileSync(src, 'utf-8')
   try {
-    const compiled = template(content)
-    const pluginJs = compiled({ options })
+    const compiled = template(content, { interpolate: /<%=([\s\S]+?)%>/g })
+    const pluginJs = compiled({ options, serialize })
     fs.writeFileSync(tmpFile, pluginJs)
     const { default: Plugin, pOptions } = await import(tmpFile).catch((err) => {
       throw new Error('Err importing plugin: ' + err)


### PR DESCRIPTION
- Now pass in serialize, in case it's used (but hopefully won't be using it).
- Reverted to using template literals (i.e., `${emitBack} ...`) in plugin.