### PR TITLE
Enabled emitback of objects

### DIFF
--- a/components/Samples.vue
+++ b/components/Samples.vue
@@ -4,14 +4,16 @@
       <label>
         Sample Object (will send "examples/sampleObj" when object changes)
       </label>
-      <b-form-input
-        :value="someObj.id"
-        type="number"
-        min="0"
-        style="width:25%;"
-        @input="changeObj($event)"
-      ></b-form-input>
-      <div>Msg: {{ someObj.msg }}</div>
+      <div>
+        <b-form-input
+          :value="someObj.id"
+          type="number"
+          min="0"
+          style="width:25%; display: inline-block;"
+          @input="changeObj($event)"
+        ></b-form-input>
+      </div>
+      <span>Msg: {{ someObj.msg }}</span>
     </div>
     <div>
       <label

--- a/components/Samples.vue
+++ b/components/Samples.vue
@@ -1,6 +1,19 @@
 <template>
   <div>
     <div>
+      <label>
+        Sample Object (will send "examples/sampleObj" when object changes)
+      </label>
+      <b-form-input
+        :value="someObj.id"
+        type="number"
+        min="0"
+        style="width:25%;"
+        @input="changeObj($event)"
+      ></b-form-input>
+      <div>Msg: {{ someObj.msg }}</div>
+    </div>
+    <div>
       <label
         >Sample Number (will send "examples/sample" event back on change)</label
       >
@@ -19,6 +32,7 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
 import { mapState2Way } from '@/utils/esm'
 
 export default {
@@ -32,6 +46,7 @@ export default {
     }
   },
   computed: {
+    ...mapState({ someObj: (state) => state.examples.someObj }),
     sample: mapState2Way({ 'examples/sample': 'examples/SET_SAMPLE' }),
     sample2: {
       get() {
@@ -50,6 +65,13 @@ export default {
   methods: {
     handleAck(ack) {
       console.log('ack received', ack)
+    },
+    changeObj(evt) {
+      const msgs = ['hi from object', 'hi again', 'another msg']
+      const id = parseInt(evt)
+      const msg = msgs[id % msgs.length]
+      const newObj = { id, msg }
+      this.$store.commit('examples/SET_SOMEOBJ', newObj)
     }
   }
 }

--- a/io/plugin.js
+++ b/io/plugin.js
@@ -7,14 +7,14 @@ import consola from 'consola'
 
 function PluginOptions() {
   let _pluginOptions
-  const svc = {}
-  if (process.env.TEST) {
-    svc.get = () => _pluginOptions
-    svc.set = (opts) => (_pluginOptions = opts)
-  } else {
-    svc.get = () => (<%= JSON.stringify(options) %>)
+  if (process.env.TEST === undefined) {
+    _pluginOptions = <%= JSON.stringify(options) %>
   }
-  return Object.freeze(svc)
+
+  return Object.freeze({
+    get: () => _pluginOptions,
+    set: (opts) => (_pluginOptions = opts)
+  })
 }
 
 const _pOptions = PluginOptions()
@@ -186,12 +186,12 @@ const register = {
                 'Is state set up correctly in your stores folder?'
               ].join('\n')
             )
-          } else if (
+          }
+           else if (
             typeof watchProp === 'object' &&
             Object.prototype.hasOwnProperty.call(watchProp, '__ob__')
           ) {
-            const errMsg = `${mapTo} is a vuex module. You probably want to watch its properties`
-            throw new Error(errMsg)
+            console.warn(`${mapTo} is an object. You probably want to watch its properties instead`)
           }
           useSocket.registeredWatchers.push(mapTo)
           return watchProp
@@ -444,6 +444,7 @@ function nuxtSocket(ioOpts) {
       socket.close()
     })
   }
+  _pOptions.set({ sockets })
   return socket
 }
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -102,6 +102,7 @@ module.exports = {
           mutations: [{ progress: 'examples/SET_PROGRESS' }],
           actions: [{ chatMessage: 'FORMAT_MESSAGE' }],
           emitBacks: [
+            'examples/someObj',
             'examples/sample',
             { 'examples/sample2': 'sample2' },
             'titleFromUser'

--- a/server/namespaces/examples.js
+++ b/server/namespaces/examples.js
@@ -32,6 +32,10 @@ function Svc() {
         resolve()
       })
     },
+    'examples/someObj': ({ data, notify }) => {
+      console.log('someObj received!', data)
+      return Promise.resolve({ msg: 'ok' })
+    },
     sample2({ data: sample, notify }) {
       return new Promise((resolve) => {
         notify({

--- a/store/examples.js
+++ b/store/examples.js
@@ -2,7 +2,11 @@ export const state = () => ({
   progress: 0,
   sample: 341,
   sample2: 243,
-  sample2b: '243b'
+  sample2b: '243b',
+  someObj: {
+    id: 0,
+    msg: ''
+  }
 })
 
 export const mutations = {
@@ -20,5 +24,9 @@ export const mutations = {
 
   SET_SAMPLE2B(state, sample2b) {
     state.sample2b = sample2b
+  },
+
+  SET_SOMEOBJ(state, someObj) {
+    Object.assign(state, { someObj })
   }
 }

--- a/test/specs/Plugin.spec.js
+++ b/test/specs/Plugin.spec.js
@@ -440,7 +440,11 @@ test('Emitback is not defined in vuex store', (t) => {
 
 test('Duplicate Watchers are not registered', async (t) => {
   const vuexOpts = {
-    emitBacks: ['examples/sample', { 'examples/sample2': 'sample2' }]
+    emitBacks: [
+      'examples/someObj',
+      'examples/sample',
+      { 'examples/sample2': 'sample2' }
+    ]
   }
   const context = {}
   const callCnt = { storeWatch: 0 }
@@ -449,7 +453,7 @@ test('Duplicate Watchers are not registered', async (t) => {
 
   // Instantiate the second socket:
   context.nuxtSocket({ default: true })
-  t.is(callCnt.storeWatch, 2)
+  t.is(callCnt.storeWatch, vuexOpts.emitBacks.length)
 })
 
 test('Namespace config (undefined)', async (t) => {

--- a/utils/common.js
+++ b/utils/common.js
@@ -1,16 +1,16 @@
+function propByPath(obj, path) {
+  return path.split(/[/.]/).reduce((out, prop) => {
+    if (out !== undefined && out[prop] !== undefined) {
+      return out[prop]
+    }
+  }, obj)
+}
+
 function mapState2Way(map) {
   const [[prop, mutation]] = Object.entries(map)
-  let stateProp = null
   return {
     get() {
-      if (!stateProp) {
-        const outProp = Object.assign({}, this.$store.state)
-        stateProp = prop.split('/').reduce((obj, nestedProp) => {
-          obj = obj[nestedProp]
-          return obj
-        }, outProp)
-      }
-      return stateProp
+      return propByPath(this.$store.state, prop)
     },
     set(newVal) {
       this.$store.commit(mutation, newVal)

--- a/utils/esm.js
+++ b/utils/esm.js
@@ -1,16 +1,16 @@
+function propByPath(obj, path) {
+  return path.split(/[/.]/).reduce((out, prop) => {
+    if (out !== undefined && out[prop] !== undefined) {
+      return out[prop]
+    }
+  }, obj)
+}
+
 function mapState2Way(map) {
   const [[prop, mutation]] = Object.entries(map)
-  let stateProp = null
   return {
     get() {
-      if (!stateProp) {
-        const outProp = Object.assign({}, this.$store.state)
-        stateProp = prop.split('/').reduce((obj, nestedProp) => {
-          obj = obj[nestedProp]
-          return obj
-        }, outProp)
-      }
-      return stateProp
+      return propByPath(this.$store.state, prop)
     },
     set(newVal) {
       this.$store.commit(mutation, newVal)


### PR DESCRIPTION
- Previously, if the developer tried to emitBack an object (an observable) and not a primitive, I threw an error. I was trying to discourage this, but people may want to do it. So, I just changed the error to a console warning. I'm not entirely a fan of sending back the entire object...my style is to send back only what changed, but other people may have different coding styles.
- Code in the examples page has been updated (See components/Samples.vue which now shows examples/someObj to see how it's done)
- I thought I prevented duplicate vuex watchers in a previous release, but realized I had to refactor the `PluginOptions` function to get it to work correctly in non-test mode. 
- I also cleaned up the mapState2Way function in the utils (esm).