### PR TITLE
Added option to disable console warnings

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -44,6 +44,7 @@ module.exports = {
     '~/io/module'
   ],
   io: {
+    warnings: false,
     sockets: [
       {
         name: 'heroku',

--- a/specs.config.js
+++ b/specs.config.js
@@ -1,6 +1,6 @@
 export default {
   require: ['@babel/register', './test/specs.setup.js'],
-  files: ['test/specs/**/*'],
+  files: ['test/specs/Module.spec.js', 'test/specs/Plugin.spec.js'],
   sources: ['**/*.{js,vue}'],
   babel: {
     testOptions: {


### PR DESCRIPTION
Normally, when not in production mode, the `console.warn` statements are there to prevent developers from shooting themselves in the foot. Warnings will be enabled by default. To disable them, specify `warnings: false` in the `nuxt.config`:

```
io: {
  warnings: false,
  sockets: [...]
}
```