### PR TITLE
Development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.0.21] - 2020-03-17
+### Added
+- Pre-emit hook validation feature for emitbacks; if validation fails, emit event won't be sent.
+
+### Fixed
+- propExists method in the plugin. Properly checks to see if the property is defined.
+
 ## [1.0.20] - 2020-03-17
 ### Added
 - Pre-emit hook validation feature; if validation fails, emit event won't be sent.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The syntax is as follows:
 * **Emitters**:
 > preEmit hook] componentMethod + msg --> componentProp [postRx hook
 
-→ The `preEmit` and `postRx` hooks are optional, but if using them, the "]" and "[" characters are needed so the plugin can parse them. As of v1.0.20, if the preEmit hook returns `false`, it will be treated as a *validation failure* and the emit event will not get sent.
+→ The `preEmit` and `postRx` hooks are optional, but if using them, the "]" and "[" characters are needed so the plugin can parse them. As of v1.0.20, if the preEmit hook returns `false`, it will be treated as a *validation failure* and the emit event will not get sent. Also, the preEmit hook will get the same "msg" data that will get sent with the emit event, in case it needs to be modified.
 
 → The `msg` is optional, but if using, must use the '+' character
 
@@ -108,7 +108,7 @@ Note: as of v1.0.12, it is now also possible to call the emitter with an argumen
 * **Emitbacks**:
 > 'preEmitHook] emitEvt <-- watchProp [postAck hook'
 
-→ `preEmitHook` and `postAck` hooks are optional. `preEmitHook` runs before emitting the event, `postAck` hook runs after receiving the acknolwedgement, if any..
+→ `preEmitHook` and `postAck` hooks are optional. `preEmitHook` runs before emitting the event, `postAck` hook runs after receiving the acknolwedgement, if any. As of v1.0.21, if the preEmit hook returns `false`, it will be treated as a *validation failure* and the emit event will not get sent. Also, the preEmit hook will get the same "msg" data that will get sent with the emit event, in case it needs to be modified.
 
 → `watchProp` is the property on the component to watch using "myObj.child.grandchild" syntax. Just like you would on the component.
 

--- a/io/plugin.js
+++ b/io/plugin.js
@@ -163,7 +163,7 @@ const register = {
       if (propExists(ctx, mapTo)) {
         debug('registered local emitBack', { mapTo })
         ctx.$watch(mapTo, async function(data, oldData) {
-          debug('local data changed', data)
+          debug('local data changed', evt, data)
           const preResult = await runHook(ctx, pre, { data, oldData })
           if (preResult === false) {
             return Promise.resolve()
@@ -206,9 +206,13 @@ const register = {
           debug('emitBack registered', { mapTo })
           return watchProp
         },
-        async (data) => {
-          debug('emitBack data changed. Emitting back', { evt, data, mapTo })
-          await runHook(ctx, pre) // TBD: pass data to pre-hook... (same idea... emit if valid)
+        async (data, oldData) => {
+          debug('vuex emitBack data changed', { emitBack: evt, data })
+          const preResult = await runHook(ctx, pre, { data, oldData })
+          if (preResult === false) {
+            return Promise.resolve()
+          }
+          debug('Emitting back:', { evt, mapTo, data })
           socket.emit(evt, { data }, (resp) => {
             runHook(ctx, post, resp)
           })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-socket-io",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "Socket.io module for Nuxt. Just plug it in and GO",
   "author": "Richard Schloss",
   "main": "io/module.js",

--- a/store/examples.js
+++ b/store/examples.js
@@ -1,4 +1,6 @@
 export const state = () => ({
+  hello: false,
+  helloFail: false,
   progress: 0,
   sample: 341,
   sample2: 243,

--- a/test/specs/Plugin.spec.js
+++ b/test/specs/Plugin.spec.js
@@ -370,7 +370,7 @@ test('Socket plugin (vuex options missing actions)', async (t) => {
   await testVuexOpts({ t, vuexOpts })
 })
 
-test.only('Socket plugin (vuex opts ok)', async (t) => {
+test('Socket plugin (vuex opts ok)', async (t) => {
   const callItems = ['pre1', 'post1', 'preEmit', 'postAck']
   const callCnt = {
     storeWatch: 0,


### PR DESCRIPTION
- Added preEmit validation feature for the emitBacks. If the preEmit hooks return false, they'll be treated as "validation failure" and the emit event won't get sent back.
- Fixed propExists method  (before, if prop were defined but `false`, the plugin wouldn't incorrectly warn the user...that's been removed now)
- The pre-emit hooks now get passed the "msg" data that would get sent with the emit event, in case the msg needs to be modified or checked before being emitted; useful if using the validation feature.