### PR TITLE
Feat/instance overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.0.22] - 2020-04-04
+### Added
+- Instance options for vuex and namespace config (that will override nuxt.config entries)
+
 ## [1.0.22] - 2020-04-03
 ### Added
 - Registration of $nuxtSocket vuex module

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ mounted(){
   this.socket = this.$nuxtSocket({
     name: 'home',
     channel: '/examples',
-    namespaceCfg: {
+    namespaceCfg: { // overrides the namespace config of "examples" above
       emitters: [],
       listeners: [],
       emitBacks: []

--- a/README.md
+++ b/README.md
@@ -82,6 +82,25 @@ modules: [
 ...
 ```
 
+### Overrides (Vuex Opts)
+
+As of v1.0.23, it is possible to now specify the vuex options when you instantiate the $nuxtSocket, using the "vuex" property:
+
+```
+mounted() {
+  this.socket = this.$nuxtSocket({
+    name: 'home',
+    vuex: { // overrides the vuex opts in the nuxt.config above.
+      mutations: ['examples/SET_PROGRESS'],
+      actions: ['FORMAT_MESSAGE'],
+      emitBacks: ['examples/sample']
+    }
+  })
+}
+```
+
+You may prefer to maintain the vuex options like this instead of in the nuxt.config. The vuex options defined in the instance will override the vuex options in the config for a given socket. Best practice is to keep things clean and avoid duplicating entries.
+
 ## Configuration (Namespaces) [↑](#nuxt-socket-io)
 
 It is also possible to configure namespaces in `nuxt.config`. Each socket set can have its own configuration of namespaces and each namespace can now have emitters, listeners, and emitbacks. The configuration supports an arrow syntax in each entry to help describe the flow (with pre/post hook designation support too).
@@ -156,6 +175,25 @@ When `this.getProgress()` is called, *first* `this.reset()` will be called (if i
 
 * Listeners:
 When event "progress" is received, `this.progress` will get set to that data.
+
+### Overrides (Namespace Config)
+
+It may turn out that you would prefer to define the namespace config when you instantiate the $nuxtSocket instead of in your `nuxt.config`. As of v1.0.23, this is now possible with the "namespaceCfg" prop:
+
+```
+mounted(){
+  this.socket = this.$nuxtSocket({
+    name: 'home',
+    channel: '/examples',
+    namespaceCfg: {
+      emitters: [],
+      listeners: [],
+      emitBacks: []
+    }
+  })
+}
+```
+
 
 ## Usage: [↑](#nuxt-socket-io)
 

--- a/io/plugin.js
+++ b/io/plugin.js
@@ -792,6 +792,7 @@ function nuxtSocket(ioOpts) {
     serverAPI,
     clientAPI,
     vuex,
+    namespaceCfg,
     ...connectOpts
   } = ioOpts
   const pluginOptions = _pOptions.get()
@@ -843,7 +844,7 @@ function nuxtSocket(ioOpts) {
   connectUrl += channel
 
   const vuexOpts = vuex || useSocket.vuex
-  const { namespaces } = useSocket
+  const { namespaces = {} } = useSocket
 
   let socket
   const label =
@@ -879,24 +880,22 @@ function nuxtSocket(ioOpts) {
     consola.info('[nuxt-socket-io]: connect', useSocket.name, connectUrl)
   }
 
-  if (namespaces) {
-    const namespaceCfg = namespaces[channel]
-    if (namespaceCfg) {
-      register.namespace({
-        ctx: this,
-        namespace: channel,
-        namespaceCfg,
-        socket,
-        useSocket,
-        emitTimeout,
-        emitErrorsProp
-      })
-      debug('namespaces configured for socket', {
-        name: useSocket.name,
-        channel,
-        namespaceCfg
-      })
-    }
+  const _namespaceCfg = namespaceCfg || namespaces[channel]
+  if (_namespaceCfg) {
+    register.namespace({
+      ctx: this,
+      namespace: channel,
+      namespaceCfg: _namespaceCfg,
+      socket,
+      useSocket,
+      emitTimeout,
+      emitErrorsProp
+    })
+    debug('namespaces configured for socket', {
+      name: useSocket.name,
+      channel,
+      namespaceCfg
+    })
   }
 
   if (serverAPI) {

--- a/io/plugin.js
+++ b/io/plugin.js
@@ -455,7 +455,7 @@ const register = {
           return watchProp
         },
         async (data, oldData) => {
-          debug('vuex emitBack data changed', { emitBack: evt, data })
+          debug('vuex emitBack data changed', { emitBack: evt, data, oldData })
           const preResult = await runHook(ctx, pre, { data, oldData })
           if (preResult === false) {
             return Promise.resolve()
@@ -791,6 +791,7 @@ function nuxtSocket(ioOpts) {
     apiIgnoreEvts = [],
     serverAPI,
     clientAPI,
+    vuex,
     ...connectOpts
   } = ioOpts
   const pluginOptions = _pOptions.get()
@@ -841,7 +842,8 @@ function nuxtSocket(ioOpts) {
   let { url: connectUrl } = useSocket
   connectUrl += channel
 
-  const { vuex: vuexOpts, namespaces } = useSocket
+  const vuexOpts = vuex || useSocket.vuex
+  const { namespaces } = useSocket
 
   let socket
   const label =

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-socket-io",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "Socket.io module for Nuxt. Just plug it in and GO",
   "author": "Richard Schloss",
   "main": "io/module.js",


### PR DESCRIPTION
Now users can specify vuexOpts and namespaceCfg *when the create the socket instance*:

Example:

```
mounted(){
  this.socket = this.$nuxtSocket({
    name: 'home',
    channel: '/examples',
    vuex: { // overrides the vuex opts in the nuxt.config above.
      mutations: ['examples/SET_PROGRESS'],
      actions: ['FORMAT_MESSAGE'],
      emitBacks: ['examples/sample']
    }
    namespaceCfg: { // overrides the namespace config of "examples" above
      emitters: [],
      listeners: [],
      emitBacks: []
    }
  })
}
```