### PR TITLE
Issue/93: default URL handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [1.0.22] - 2020-04-04
+## [1.0.24] - 2020-04-05
+### Added
+- Default handler for url missing. Now `window.location` will be used.
+
+### Changed
+- Before when URL was empty, an error would be thrown. Now it will just be a warning.
+
+## [1.0.23] - 2020-04-04
 ### Added
 - Instance options for vuex and namespace config (that will override nuxt.config entries)
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ modules: [
 ...
 ```
 
+### Defaults
+
+* URL - As of v1.0.24, If url is omitted, it will default to `window.location`
+
 ### Overrides (Vuex Opts)
 
 As of v1.0.23, it is possible to now specify the vuex options when you instantiate the $nuxtSocket, using the "vuex" property:
@@ -103,7 +107,7 @@ You may prefer to maintain the vuex options like this instead of in the nuxt.con
 
 ## Configuration (Namespaces) [↑](#nuxt-socket-io)
 
-It is also possible to configure namespaces in `nuxt.config`. Each socket set can have its own configuration of namespaces and each namespace can now have emitters, listeners, and emitbacks. The configuration supports an arrow syntax in each entry to help describe the flow (with pre/post hook designation support too).
+It is also possible to configure [namespaces](https://socket.io/docs/rooms-and-namespaces/) in `nuxt.config`. Each socket set can have its own configuration of namespaces and each namespace can now have emitters, listeners, and emitbacks. The configuration supports an arrow syntax in each entry to help describe the flow (with pre/post hook designation support too).
 
 The syntax is as follows:
 * **Emitters**:

--- a/io/plugin.js
+++ b/io/plugin.js
@@ -866,23 +866,31 @@ function nuxtSocket(ioOpts) {
     store.commit('$nuxtSocket/SET_EMIT_TIMEOUT', { label, emitTimeout })
   }
 
+  function connectSocket() {
+    if (connectUrl) {
+      socket = io(connectUrl, connectOpts)
+      consola.info('[nuxt-socket-io]: connect', useSocket.name, connectUrl)
+    } else {
+      socket = io(connectOpts)
+      consola.info('[nuxt-socket-io]: connect', useSocket.name, window.location)
+    }
+  }
+
   if (persist) {
     if (store.state.$nuxtSocket.sockets[label]) {
       debug(`resuing persisted socket ${label}`)
       socket = store.state.$nuxtSocket.sockets[label]
       if (socket.disconnected) {
         debug('persisted socket disconnected, reconnecting...')
-        socket = connectUrl ? io(connectOpts) : io(connectUrl, connectOpts)
+        connectSocket()
       }
     } else {
       debug(`socket ${label} does not exist, creating and connecting to it..`)
-      socket = connectUrl ? io(connectOpts) : io(connectUrl, connectOpts)
-      consola.info('[nuxt-socket-io]: connect', useSocket.name, connectUrl)
+      connectSocket()
       store.commit('$nuxtSocket/SET_SOCKET', { label, socket })
     }
   } else {
-    socket = connectUrl ? io(connectOpts) : io(connectUrl, connectOpts)
-    consola.info('[nuxt-socket-io]: connect', useSocket.name, connectUrl)
+    connectSocket()
   }
 
   const _namespaceCfg = namespaceCfg || namespaces[channel]

--- a/io/plugin.js
+++ b/io/plugin.js
@@ -829,7 +829,10 @@ function nuxtSocket(ioOpts) {
   }
 
   if (!useSocket.url) {
-    throw new Error('URL must be defined for nuxtSocket')
+    warn(
+      `URL not defined for socket "${useSocket.name}". Defaulting to "window.location"\r\n` +
+      `NOTE: channel ${channel} will be ignored`
+    )
   }
 
   if (!useSocket.registeredWatchers) {
@@ -841,7 +844,9 @@ function nuxtSocket(ioOpts) {
   }
 
   let { url: connectUrl } = useSocket
-  connectUrl += channel
+  if (connectUrl) {
+    connectUrl += channel
+  }
 
   const vuexOpts = vuex || useSocket.vuex
   const { namespaces = {} } = useSocket
@@ -867,16 +872,16 @@ function nuxtSocket(ioOpts) {
       socket = store.state.$nuxtSocket.sockets[label]
       if (socket.disconnected) {
         debug('persisted socket disconnected, reconnecting...')
-        socket = io(connectUrl, connectOpts)
+        socket = connectUrl ? io(connectOpts) : io(connectUrl, connectOpts)
       }
     } else {
       debug(`socket ${label} does not exist, creating and connecting to it..`)
-      socket = io(connectUrl, connectOpts)
+      socket = connectUrl ? io(connectOpts) : io(connectUrl, connectOpts)
       consola.info('[nuxt-socket-io]: connect', useSocket.name, connectUrl)
       store.commit('$nuxtSocket/SET_SOCKET', { label, socket })
     }
   } else {
-    socket = io(connectUrl, connectOpts)
+    socket = connectUrl ? io(connectOpts) : io(connectUrl, connectOpts)
     consola.info('[nuxt-socket-io]: connect', useSocket.name, connectUrl)
   }
 

--- a/io/plugin.js
+++ b/io/plugin.js
@@ -829,10 +829,7 @@ function nuxtSocket(ioOpts) {
   }
 
   if (!useSocket.url) {
-    warn(
-      `URL not defined for socket "${useSocket.name}". Defaulting to "window.location"\r\n` +
-      `NOTE: channel ${channel} will be ignored`
-    )
+    warn(`URL not defined for socket "${useSocket.name}". Defaulting to "window.location"`)
   }
 
   if (!useSocket.registeredWatchers) {
@@ -871,8 +868,8 @@ function nuxtSocket(ioOpts) {
       socket = io(connectUrl, connectOpts)
       consola.info('[nuxt-socket-io]: connect', useSocket.name, connectUrl)
     } else {
-      socket = io(connectOpts)
-      consola.info('[nuxt-socket-io]: connect', useSocket.name, window.location)
+      socket = io(channel, connectOpts)
+      consola.info('[nuxt-socket-io]: connect', useSocket.name, window.location, channel)
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-socket-io",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Socket.io module for Nuxt. Just plug it in and GO",
   "author": "Richard Schloss",
   "main": "io/module.js",

--- a/test/specs/Plugin.spec.js
+++ b/test/specs/Plugin.spec.js
@@ -793,12 +793,16 @@ test('Socket plugin (malformed sockets)', async (t) => {
 test('Socket plugin (options missing info)', async (t) => {
   const jsdom = require('jsdom-global')
   const testCfg = { sockets: [{}] }
+  const ioOpts = {
+    channel: '/dynamic'
+  }
   const windowUrl = 'http://localhost:3000'
   pOptions.set(testCfg)
 
   jsdom('', { url: windowUrl })
-  const socket = await loadPlugin({ t })
-  t.is(socket.io.uri, windowUrl)
+  const socket = await loadPlugin({ t, ioOpts })
+  await socketConnected(socket)
+  t.is(socket.io.uri, windowUrl + ioOpts.channel)
 })
 
 test('Socket plugin (no vuex options)', async (t) => {

--- a/test/specs/Plugin.spec.js
+++ b/test/specs/Plugin.spec.js
@@ -791,11 +791,14 @@ test('Socket plugin (malformed sockets)', async (t) => {
 })
 
 test('Socket plugin (options missing info)', async (t) => {
+  const jsdom = require('jsdom-global')
   const testCfg = { sockets: [{}] }
+  const windowUrl = 'http://localhost:3000'
   pOptions.set(testCfg)
-  await loadPlugin({ t }).catch((e) => {
-    t.is(e.message, 'URL must be defined for nuxtSocket')
-  })
+
+  jsdom('', { url: windowUrl })
+  const socket = await loadPlugin({ t })
+  t.is(socket.io.uri, windowUrl)
 })
 
 test('Socket plugin (no vuex options)', async (t) => {


### PR DESCRIPTION
- Now the URL will default to window.location (just like socket.io-client does). But, in order to make it respect the channel, I still have to pass that in. I think it will still work with channel being an empty string.
- The error for unspecified URL was replaced with a console warning.
- Updated docs