### PR TITLE
Fix in namespace solving for windows

### DIFF
--- a/io/module.js
+++ b/io/module.js
@@ -34,8 +34,8 @@ const register = {
   },
   nspSvc(io, nspDir) {
     return new Promise(async (resolve, reject) => {
-      const nspFiles = await glob(`${nspDir}/**/*.{js,ts, mjs}`)
-      const nspDirResolved = pResolve(nspDir.replace(/\\/g, '/'))
+      const nspFiles = await glob(`${nspDir}/**/*.{js,ts,mjs}`)
+      const nspDirResolved = pResolve(nspDir).replace(/\\/g, '/')
       const namespaces = nspFiles.map(
         (f) => f.split(nspDirResolved)[1].split(/.(js|ts|mjs)/)[0]
       )


### PR DESCRIPTION
With the introduction of new logic using pResolve the bug appeared again.
Its just the replace which was in the wrong place.