### PR TITLE
Make NuxtSocketOpts Partial

### DIFF
--- a/io/types.d.ts
+++ b/io/types.d.ts
@@ -128,7 +128,7 @@ interface NuxtSocketIoServerOpts {
   port?: number;
 }
 
-export interface NuxtSocketOpts extends ManagerOptions {
+export interface NuxtSocketOpts extends Partial<ManagerOptions> {
   /** Name of the socket. If omitted, the default socket will be used. */
   name?: string;
   /**


### PR DESCRIPTION
Amends #210

Missed this in my previous PR (#215) - Unlike the old `SocketIOClient.ConnectOpts`, `ManagerOpts` uses required properties, but is wrapped as partial where used. Thus the inherited props of `NuxtSocketOpts` are required, while its own properties are not.
As Factory is `(ioOpts: NuxtSocketOpts) => NuxtSocket` and not `(ioOpts: Partial<NuxtSocketOpts>) => NuxtSocket`.
Thus my previous PR was errored.

Alternative to this commit would be to follow in Socket's stead, making the properties of `NuxtSocketOpts` required, and changing the type of Factory to `(ioOpts: Partial<NuxtSocketOpts>) => NuxtSocket`. 
