### PR TITLE
Fix namespace file regex match pattern

### DIFF
--- a/io/module.js
+++ b/io/module.js
@@ -45,7 +45,7 @@ const register = {
       const nspFiles = await glob(`${nspDir}/**/*.{js,ts,mjs}`)
       const nspDirResolved = pResolve(nspDir).replace(/\\/g, '/')
       const namespaces = nspFiles.map(
-        (f) => f.split(nspDirResolved)[1].split(/.(js|ts|mjs)/)[0]
+        (f) => f.split(nspDirResolved)[1].split(/\.(js|ts|mjs)$/)[0]
       )
       namespaces.forEach(async (namespace, idx) => {
         const {


### PR DESCRIPTION
I've encountered a bug where certain namespace files are not registered properly.

For example, if I create a file server/io/bots.js, nuxt-socket-io will register a '/b' namespace instead of '/bots'. Same goes for dots, pots, etc.

This is because `.split(/\.(js|ts|mjs)$/)` will split on any symbol (dot), followed by js|ts|mjs, and since bots/dots/pots follow this pattern, their names are split incorrectly and hence registered under a wrong name.

This PR fixes the problem.