### PR TITLE
Updates the composition-api example to use Nuxt3's built-in support

### DIFF
--- a/components/Composition1.vue
+++ b/components/Composition1.vue
@@ -1,59 +1,24 @@
 <template>
   <div>
-    Component using composition api
-    <!-- <button @click="getMessage2('hello world')">
-      Get Message
-    </button>
-    <div>{{ message2Rxd }}</div> -->
+    <label>Id</label>
+    <input v-model="id" class="form-control"/>
+    <button class="btn btn-primary" @click="getMessage()" v-text="'Get Message'" />
+    <p class="text-left" style="color: grey; white-space: pre-line;" v-text="msg" />
   </div>
 </template>
-<script>
-// @ts-nocheck
-// import {
-//   defineComponent,
-//   useContext,
-//   onUnmounted,
-//   toRefs,
-//   reactive,
-//   watch
-// } from '@nuxtjs/composition-api'
+<script setup>
+const ctx = useNuxtApp()
+const id  = ref('abc123')
+const msg = ref('^^Click the button')
+let socket
+const getMessage = async () => {
+  msg.value = await socket.emitP('getMessage', { id: id.value })
+}
+onMounted(() => {
+  socket = ctx.$nuxtSocket({
+    channel: '/index'
+  })
+})
 
-// export default defineComponent({
-//   setup(props, context) {
-//     const ctx = useContext()
-//     ctx.$data = toRefs(
-//       reactive({
-//         message2Rxd: 'this should change'
-//       })
-//     )
-//     ctx.$destroy = () => {
-//       // eslint-disable-next-line no-console
-//       console.log('run me too')
-//     }
-//     ctx.onUnmounted = onUnmounted
-//     ctx.$nuxtSocket({
-//       channel: '/index',
-//       reconnection: false
-//     })
-//     ctx.$nuxtSocket({
-//       channel: '/index',
-//       reconnection: false
-//     })
-//     ctx.getMessage2('see me??')
-//     ctx.$watch = (label, cb) => {
-//       // This stub will be enabled
-//       // in the plugin when '@nuxtjs/composition-api' reaches stable version:
-//       watch(ctx.$data[label], cb)
-//     }
-//     ctx.$watch('message2Rxd', (n, o) => {
-//       // eslint-disable-next-line no-console
-//       console.log('message2Rxd changed', n, o)
-//     })
 
-//     return {
-//       ...ctx.$data,
-//       getMessage2: ctx.getMessage2
-//     }
-//   }
-// })
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "nuxt-socket-io",
-  "version": "3.0.9",
+  "version": "3.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nuxt-socket-io",
-      "version": "3.0.9",
+      "version": "3.0.12",
       "license": "MIT",
       "dependencies": {
         "@nuxt/types": "^2.15.5",
         "glob": "^7.1.7",
-        "socket.io": "^4.1.1",
-        "socket.io-client": "^4.1.1",
+        "socket.io": "4.1.1",
+        "socket.io-client": "4.1.1",
         "tiny-emitter": "^2.1.0"
       },
       "devDependencies": {

--- a/pages/composition.vue
+++ b/pages/composition.vue
@@ -1,18 +1,6 @@
 <template>
   <div class="container">
-    Composition...
-    <br>
-    <input v-model="showIt" type="checkbox">
-    <!-- <Composition1 v-if="showIt" /> -->
+    Composition API...
+    <Composition1 />
   </div>
 </template>
-
-<script>
-export default {
-  data () {
-    return {
-      showIt: true
-    }
-  }
-}
-</script>


### PR DESCRIPTION
Now in Nuxt3, the composition-api is built-in. There's no longer the need to specify it in devDeps. Currently, when we want to use the composition api and nuxt-socket, the plugin depends on a context being defined:

```js
  const ctx = useNuxtApp()
  const socket = ctx.$nuxtSocket({...})
```

But we may want to be able to do this:

```js
const { $nuxtSocket } = useNuxtApp()
const socket = $nuxtSocket({...}) // Less typing, arguably cleaner code.
```

In the plugin, there are various parts that set `ctx` to `this` when it should probably default to `useNuxtApp()` if `this` is undefined.